### PR TITLE
Feat/#1 #5 suji

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import Router from './router/Router';
 import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
@@ -11,9 +12,10 @@ const GlobalStyle = createGlobalStyle`
   }
   
 `;
+
 function App() {
   <GlobalStyle />;
-  return <div>1</div>;
+  return <Router />;
 }
 
 export default App;

--- a/src/api/dataApi.ts
+++ b/src/api/dataApi.ts
@@ -1,0 +1,14 @@
+import { TODAY } from '../constants/orders';
+import { DataType } from '../types/data.types';
+import axios from 'axios';
+
+export const getTodayDataApi = async () => {
+  const response = await axios.get('/data/mockData.json');
+  const data = response.data;
+
+  const filteredData = data.filter((data: DataType) =>
+    data.transaction_time.includes(TODAY)
+  );
+
+  return filteredData;
+};

--- a/src/api/temp.tsx
+++ b/src/api/temp.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function temp() {
-  return <div>temp</div>;
-}

--- a/src/component/Pagination.tsx
+++ b/src/component/Pagination.tsx
@@ -1,0 +1,59 @@
+import { COLORS } from '../constants/colors';
+import usePageData from '../hooks/usePageData';
+import usePagination from '../hooks/usePagination';
+import styled from 'styled-components';
+
+export default function Pagination() {
+  const { handlePage, handleLeftPage, handleRightPage } = usePagination();
+  const { page, numPages } = usePageData();
+
+  return (
+    <PaginationWrapper>
+      <button onClick={() => handleLeftPage(page)} disabled={page === 1}>
+        Prev
+      </button>
+      {Array(numPages)
+        .fill(0)
+        .map((_, i) => (
+          <button
+            key={i + 1}
+            onClick={() => handlePage(i + 1)}
+            aria-current={page === i + 1 ? 'page' : undefined}>
+            {i + 1}
+          </button>
+        ))}
+      <button onClick={() => handleRightPage(page)}>Next</button>
+    </PaginationWrapper>
+  );
+}
+
+const PaginationWrapper = styled.div`
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  margin-top: 30px;
+  & button {
+    background-color: white;
+    border: 1px solid lightgray;
+    color: gray;
+    border-radius: 5px;
+    padding: 8px 16px;
+  }
+  & button:hover:not([aria-current]):not([disabled]) {
+    background-color: ${COLORS.orangeBG};
+    cursor: pointer;
+  }
+  & [disabled] {
+    background: ${COLORS.lightGray};
+    color: lightgray;
+    cursor: revert;
+    transform: revert;
+  }
+  & [aria-current] {
+    background-color: ${COLORS.orange};
+    color: white;
+    font-weight: bold;
+    cursor: revert;
+    transform: revert;
+  }
+`;

--- a/src/component/Table.tsx
+++ b/src/component/Table.tsx
@@ -51,8 +51,9 @@ const TableWrapper = styled.table`
 `;
 
 const TableHead = styled.thead`
+  top: 0;
   position: sticky;
-  fornt-weight: bold;
+  font-weight: bold;
   background-color: ${COLORS.orange};
   color: white;
 

--- a/src/component/Table.tsx
+++ b/src/component/Table.tsx
@@ -1,0 +1,72 @@
+import { COLORS } from '../constants/colors';
+import usePageData from '../hooks/usePageData';
+import { DataType } from '../types/data.types';
+import styled from 'styled-components';
+
+export default function Table() {
+  const { paginatedData } = usePageData();
+
+  return (
+    <TableWrapper>
+      <TableHead>
+        <tr>
+          <th>주문번호</th>
+          <th>거래시간</th>
+          <th>주문처리상태</th>
+          <th>고객번호</th>
+          <th>고객이름</th>
+          <th>가격</th>
+        </tr>
+      </TableHead>
+      <TableBody>
+        {paginatedData.map((order: DataType) => (
+          <tr key={order.id}>
+            <td>{order.id}</td>
+            <td>{order.transaction_time}</td>
+            <td
+              style={
+                order.status
+                  ? { color: `${COLORS.blue}` }
+                  : { color: `${COLORS.red}` }
+              }>
+              {order.status ? 'O' : 'X'}
+            </td>
+            <td>{order.customer_id}</td>
+            <td>{order.customer_name}</td>
+            <td>{order.currency}</td>
+          </tr>
+        ))}
+      </TableBody>
+    </TableWrapper>
+  );
+}
+
+const TableWrapper = styled.table`
+  width: 100%;
+
+  td,
+  th {
+    padding: 1em 0.5em;
+  }
+`;
+
+const TableHead = styled.thead`
+  position: sticky;
+  fornt-weight: bold;
+  background-color: ${COLORS.orange};
+  color: white;
+
+  & th:first-child {
+    border-top-left-radius: 8px;
+  }
+  & th:last-child {
+    border-top-right-radius: 8px;
+  }
+`;
+
+const TableBody = styled.tbody`
+  text-align: center;
+  & tr:nth-child(odd) {
+    background-color: white;
+  }
+`;

--- a/src/component/TableContainer.tsx
+++ b/src/component/TableContainer.tsx
@@ -1,0 +1,29 @@
+import { COLORS } from '../constants/colors';
+import Pagination from './Pagination';
+import Table from './Table';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import styled from 'styled-components';
+
+export default function TableContainer() {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TableWrapper>
+        <Table />
+      </TableWrapper>
+      <Pagination />
+    </QueryClientProvider>
+  );
+}
+
+const TableWrapper = styled.div`
+  width: 100%;
+  max-width: 1280px;
+  height: calc(100vh - 300px);
+  border: 1px solid lightgray;
+  border-radius: 10px;
+  overflow: auto;
+  margin: 0 auto;
+  background-color: ${COLORS.lightGray};
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+`;

--- a/src/component/common/Header.tsx
+++ b/src/component/common/Header.tsx
@@ -1,0 +1,32 @@
+import { COLORS } from '../../constants/colors';
+import { TODAY } from '../../constants/orders';
+import React from 'react';
+import styled from 'styled-components';
+
+export default function Header() {
+  return (
+    <HeaderWrapper>
+      <Title>SWITCHWON</Title>
+      <SubTitle>TODAY ORDER LIST(in {TODAY})</SubTitle>
+    </HeaderWrapper>
+  );
+}
+
+const HeaderWrapper = styled.div`
+  width: 100%;
+  text-align: center;
+`;
+
+const Title = styled.h1`
+  font-size: 3rem;
+  font-weight: bold;
+  color: ${COLORS.orange};
+  margin-bottom: 0;
+`;
+
+const SubTitle = styled.div`
+  color: gray;
+  font-weight: bold;
+  font-size: 1.5rem;
+  margin-bottom: 2rem;
+`;

--- a/src/component/common/temp.tsx
+++ b/src/component/common/temp.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function temp() {
-  return <div>temp</div>;
-}

--- a/src/component/temp.tsx
+++ b/src/component/temp.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function temp() {
-  return <div>temp</div>;
-}

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,0 +1,7 @@
+export const COLORS = {
+  orangeBG: '#fffaf6',
+  orange: '#f7941d',
+  lightGray: '#fafafa',
+  red: '#fb4e4f',
+  blue: '#4a79ff',
+} as const;

--- a/src/constants/orders.ts
+++ b/src/constants/orders.ts
@@ -1,0 +1,2 @@
+export const TODAY = '2023-03-08';
+export const PAGESIZE = 50;

--- a/src/hooks/temp.tsx
+++ b/src/hooks/temp.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function temp() {
-  return <div>temp</div>;
-}

--- a/src/hooks/useOrderData.ts
+++ b/src/hooks/useOrderData.ts
@@ -1,0 +1,23 @@
+import { getTodayDataApi } from '../api/dataApi';
+import React, { useEffect, useState } from 'react';
+import { useQuery } from 'react-query';
+
+const useOrderData = () => {
+  const [pageList, setPageList] = useState([]);
+
+  const { data: todayData } = useQuery('todayData', getTodayDataApi, {
+    refetchInterval: 5000,
+  });
+
+  useEffect(() => {
+    if (todayData) {
+      setPageList(todayData);
+    }
+  }, [todayData]);
+
+  return {
+    pageList,
+  };
+};
+
+export default useOrderData;

--- a/src/hooks/usePageData.ts
+++ b/src/hooks/usePageData.ts
@@ -1,0 +1,25 @@
+import { PAGESIZE } from '../constants/orders';
+import useOrderData from './useOrderData';
+import { useSearchParams } from 'react-router-dom';
+
+const usePageData = () => {
+  const { pageList } = useOrderData();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = Number(searchParams.get('page')) || 1;
+  const numPages = Math.ceil(pageList.length / PAGESIZE);
+
+  const start = (page - 1) * PAGESIZE;
+  const end = start + PAGESIZE;
+  const paginatedData = pageList.slice(start, end);
+
+  return {
+    page,
+    numPages,
+    searchParams,
+    setSearchParams,
+    paginatedData,
+  };
+};
+
+export default usePageData;

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,27 @@
+import usePageData from './usePageData';
+
+const usePagination = () => {
+  const { numPages, searchParams, setSearchParams } = usePageData();
+
+  const handlePage = (page: number) => {
+    searchParams.set('page', String(page));
+    setSearchParams(searchParams);
+  };
+  const handleLeftPage = (page: number) => {
+    if (page === 1) return;
+    searchParams.set('page', String(page - 1));
+    setSearchParams(searchParams);
+  };
+  const handleRightPage = (page: number) => {
+    if (page === numPages) return;
+    searchParams.set('page', String(page + 1));
+    setSearchParams(searchParams);
+  };
+  return {
+    handlePage,
+    handleLeftPage,
+    handleRightPage,
+  };
+};
+
+export default usePagination;

--- a/src/pages/Mainpage.tsx
+++ b/src/pages/Mainpage.tsx
@@ -1,5 +1,12 @@
+import TableContainer from '../component/TableContainer';
+import Header from '../component/common/Header';
 import React from 'react';
 
 export default function Mainpage() {
-  return <div>Mainpage</div>;
+  return (
+    <>
+      <Header />
+      <TableContainer />
+    </>
+  );
 }

--- a/src/types/data.types.ts
+++ b/src/types/data.types.ts
@@ -1,0 +1,8 @@
+export interface DataType {
+  id: number;
+  transaction_time: string;
+  status: boolean;
+  customer_id: number;
+  customer_name: string;
+  currency: string;
+}


### PR DESCRIPTION
# #1 요구사항 
1. 주어진 데이터를 이용하여 주문 목록 페이지를 구현해주세요
 - [x] 주문 목록 페이지에는 주문에 대한 모든 정보를 표 형태로 확인할 수 있어야 합니다.
 - [x] 주문 목록은 페이지네이션이 구현되어야 합니다(한 페이지에 50건의 주문이 보여야 합니다)
- [x] 데이터 중에서 오늘의 거래건만 보여지도록 해주세요
  - 여기서 오늘은 **2023-03-08**일을 의미합니다.
5. - [x] 서버에 들어온 주문을 5초마다 최신화 해주세요
  - 서버 API는 구현되어 있지 않지만, 구현되어 있다는 가정 하에 요구사항을 충족해주세요

## 구현사항
- `useSearchParams` 사용하여 페이지네이션 구현
- `react-query` 사용하여 data 최신화 구현 
- 데이터 조건(1. 오늘의 거래 건 **2023-03-08** 2. 한 페이지에 **50**건의 주문) 상수 관리
- `주문처리상태` O/X 및 컬러 부여하여 사용자 직관화 
- 1 페이지일 때, `prev` 버튼 `disabled` 속성 추가 
- `aria-current` 속성 활용하여 활성화 버튼 표시
- custom Hook으로 pagination 관심사 분리 
- [스위치원](http://www.switchwon.com/ko/index.html#4) 느낌이 났으면 좋겠어서, 홈페이지에서 컬러를 뽑아 차트를 구현했습니다.

![요구사항1,5-수정](https://user-images.githubusercontent.com/78632299/226505560-262a4619-0cb0-404d-b623-64c6fccc5d07.gif)

## 기타
- `th` 태그에 `position: sticky` 적용하여 스크롤이 내려가도 고정되게 하고싶었는데, 제대로 적용이 안되는 문제가 발생했었습니다 > 혜수님 도움으로 해결🙌