### PR TITLE
Feat/#18 hyesu

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!axios)/\" --verbose --coverage",
     "eject": "react-scripts eject",
     "postinstall": "husky install",
     "format": "prettier --cache --write .",

--- a/src/__test__/AdminBody.test.tsx
+++ b/src/__test__/AdminBody.test.tsx
@@ -1,0 +1,66 @@
+import AdminBody from './../component/AdminBody';
+import { setup } from './setup.test';
+import '@testing-library/jest-dom/extend-expect';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('AdminBody', () => {
+  beforeEach(() => {
+    setup(<AdminBody />);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('한 페이지에 오늘의 거래 건으로 50건의 주문이 보여야한다.', async () => {
+    const tableBodyRows = await screen.findAllByTestId('table-body-row');
+
+    expect(tableBodyRows.length).toBeLessThanOrEqual(50);
+    tableBodyRows.forEach(row => expect(row).toHaveTextContent('2023-03-08'));
+  });
+
+  it('주문번호, 거래일자 버튼을 누르면 내림차순 정렬이 되어야한다.', async () => {
+    const getSorted = (array: any) => {
+      return [...array].sort((a, b) => (b > a ? 1 : -1));
+    };
+
+    const id = await screen.findByTestId('table-header-cell-id');
+    userEvent.click(id);
+    const idCell = await screen.findAllByTestId('table-body-cell-id');
+    const idText = idCell.map(Number);
+
+    expect(idText).toEqual(getSorted(idText));
+
+    const time = await screen.findByTestId(
+      'table-header-cell-transaction_time'
+    );
+    userEvent.click(time);
+    const timeCell = await screen.findAllByTestId(
+      'table-body-cell-transaction_time'
+    );
+    const timeText = timeCell.map(item => String(item.textContent));
+
+    expect(timeText).toEqual(getSorted(timeText));
+  });
+
+  it('주문상태를 한번 누르면 true인 데이터들만 보여져야한다.', async () => {
+    const status = await screen.findByTestId('table-body-filter-btn');
+
+    userEvent.click(status);
+
+    const statusCell = await screen.findAllByTestId('table-body-cell-status');
+    statusCell.forEach(cell => expect(cell.textContent).toBe('true'));
+  });
+
+  it('주문상태를 두번 누르면 false인 데이터들만 보여져야한다.', async () => {
+    const status = await screen.findByTestId('table-body-filter-btn');
+
+    userEvent.click(status);
+    userEvent.click(status);
+
+    const statusCell = await screen.findAllByTestId('table-body-cell-status');
+    statusCell.forEach(cell => expect(cell.textContent).toBe('false'));
+  });
+});

--- a/src/__test__/AdminBody.test.tsx
+++ b/src/__test__/AdminBody.test.tsx
@@ -1,12 +1,13 @@
 import AdminBody from './../component/AdminBody';
-import { setup } from './setup.test';
+import { renderAll, setup } from './setup.test';
 import '@testing-library/jest-dom/extend-expect';
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 describe('AdminBody', () => {
   beforeEach(() => {
-    setup(<AdminBody />);
+    setup();
+    renderAll(<AdminBody />);
   });
 
   afterEach(() => {

--- a/src/__test__/Mainpage.test.tsx
+++ b/src/__test__/Mainpage.test.tsx
@@ -1,0 +1,33 @@
+import Mainpage from './../pages/Mainpage';
+import { setup, renderAll } from './setup.test';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('Mainpage', () => {
+  beforeEach(() => {
+    setup();
+    renderAll(<Mainpage />);
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('검색창에 검색하는 단어를 포함한 이름의 고객이 표에 보여져야한다.', async () => {
+    const keyword = 'Holmes Howard';
+    const searchBar = (await screen.findByTestId(
+      'admin-search-bar'
+    )) as HTMLInputElement;
+
+    userEvent.type(searchBar, keyword);
+
+    const userIdCell = await screen.findAllByTestId(
+      'table-body-cell-customer_name'
+    );
+
+    userIdCell.forEach(id => {
+      expect(id).toHaveTextContent(keyword);
+    });
+  });
+});

--- a/src/__test__/setup.test.tsx
+++ b/src/__test__/setup.test.tsx
@@ -1,0 +1,103 @@
+import SearchContextProvider from '../context/SearchContext';
+import { DataType } from '../types/data.types';
+import mockData from './../../public/data/mockData.json';
+import * as api from './../api/dataApi';
+import * as useTableData from './../hooks/useTableData';
+import { QueryClient } from '@tanstack/query-core';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ColumnDef } from '@tanstack/react-table';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+
+const columns: ColumnDef<DataType, unknown>[] = [
+  {
+    header: '주문번호',
+    accessorKey: 'id',
+    sortingFn: 'datetime',
+    enableSorting: true,
+    enableColumnFilter: false,
+    filterFn: 'equals',
+    sortDescFirst: true,
+  },
+  {
+    header: '거래시간',
+    accessorKey: 'transaction_time',
+    sortingFn: 'datetime',
+    enableSorting: true,
+    enableColumnFilter: false,
+    filterFn: 'equals',
+    sortDescFirst: true,
+  },
+  {
+    header: '주문처리상태',
+    accessorKey: 'status',
+    enableSorting: false,
+    enableColumnFilter: true,
+    filterFn: 'equals',
+    sortDescFirst: true,
+  },
+  {
+    header: '고객번호',
+    accessorKey: 'customer_id',
+    enableSorting: false,
+    enableColumnFilter: false,
+    filterFn: 'equals',
+    sortDescFirst: true,
+  },
+  {
+    header: '고객이름',
+    accessorKey: 'customer_name',
+    enableSorting: false,
+    enableColumnFilter: false,
+    filterFn: 'equals',
+    sortDescFirst: true,
+  },
+  {
+    header: '가격',
+    accessorKey: 'currency',
+    enableSorting: false,
+    enableColumnFilter: false,
+    filterFn: 'equals',
+    sortDescFirst: true,
+  },
+];
+
+const data = mockData
+  .filter(data => data.transaction_time.includes('2023-03-08'))
+  .slice(0, 50);
+
+export const setup = (children: ReactNode) => {
+  const queryClient = new QueryClient();
+
+  jest.spyOn(api, 'getTodayDataApi').mockResolvedValue(data);
+
+  jest.spyOn(api, 'getOriginDataApi').mockResolvedValue([...mockData]);
+
+  jest.spyOn(useTableData, 'default').mockReturnValue({
+    columns,
+    data,
+  });
+
+  jest.mock('@tanstack/react-query', () => ({
+    ...jest.requireActual('@tanstack/react-query'),
+    useQueryClient: () => ({
+      ...jest.requireActual('@tanstack/react-query').useQueryClient(),
+      useQuery: jest.fn().mockReturnValue({
+        data: {},
+        isLoading: false,
+        isSuccess: true,
+        error: {},
+      }),
+    }),
+  }));
+
+  render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <SearchContextProvider>{children}</SearchContextProvider>
+      </QueryClientProvider>
+    </BrowserRouter>
+  );
+};

--- a/src/__test__/setup.test.tsx
+++ b/src/__test__/setup.test.tsx
@@ -68,17 +68,15 @@ const data = mockData
   .filter(data => data.transaction_time.includes('2023-03-08'))
   .slice(0, 50);
 
-export const setup = (children: ReactNode) => {
-  const queryClient = new QueryClient();
-
+export const setup = () => {
   jest.spyOn(api, 'getTodayDataApi').mockResolvedValue(data);
 
   jest.spyOn(api, 'getOriginDataApi').mockResolvedValue([...mockData]);
 
-  jest.spyOn(useTableData, 'default').mockReturnValue({
+  jest.spyOn(useTableData, 'default').mockImplementation(dataList => ({
     columns,
-    data,
-  });
+    data: dataList,
+  }));
 
   jest.mock('@tanstack/react-query', () => ({
     ...jest.requireActual('@tanstack/react-query'),
@@ -92,6 +90,10 @@ export const setup = (children: ReactNode) => {
       }),
     }),
   }));
+};
+
+export const renderAll = (children: ReactNode) => {
+  const queryClient = new QueryClient();
 
   render(
     <BrowserRouter>

--- a/src/__test__/setup.test.tsx
+++ b/src/__test__/setup.test.tsx
@@ -1,68 +1,12 @@
 import SearchContextProvider from '../context/SearchContext';
-import { DataType } from '../types/data.types';
 import mockData from './../../public/data/mockData.json';
 import * as api from './../api/dataApi';
-import * as useTableData from './../hooks/useTableData';
 import { QueryClient } from '@tanstack/query-core';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { ColumnDef } from '@tanstack/react-table';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-
-const columns: ColumnDef<DataType, unknown>[] = [
-  {
-    header: '주문번호',
-    accessorKey: 'id',
-    sortingFn: 'datetime',
-    enableSorting: true,
-    enableColumnFilter: false,
-    filterFn: 'equals',
-    sortDescFirst: true,
-  },
-  {
-    header: '거래시간',
-    accessorKey: 'transaction_time',
-    sortingFn: 'datetime',
-    enableSorting: true,
-    enableColumnFilter: false,
-    filterFn: 'equals',
-    sortDescFirst: true,
-  },
-  {
-    header: '주문처리상태',
-    accessorKey: 'status',
-    enableSorting: false,
-    enableColumnFilter: true,
-    filterFn: 'equals',
-    sortDescFirst: true,
-  },
-  {
-    header: '고객번호',
-    accessorKey: 'customer_id',
-    enableSorting: false,
-    enableColumnFilter: false,
-    filterFn: 'equals',
-    sortDescFirst: true,
-  },
-  {
-    header: '고객이름',
-    accessorKey: 'customer_name',
-    enableSorting: false,
-    enableColumnFilter: false,
-    filterFn: 'equals',
-    sortDescFirst: true,
-  },
-  {
-    header: '가격',
-    accessorKey: 'currency',
-    enableSorting: false,
-    enableColumnFilter: false,
-    filterFn: 'equals',
-    sortDescFirst: true,
-  },
-];
 
 const data = mockData
   .filter(data => data.transaction_time.includes('2023-03-08'))
@@ -72,24 +16,6 @@ export const setup = () => {
   jest.spyOn(api, 'getTodayDataApi').mockResolvedValue(data);
 
   jest.spyOn(api, 'getOriginDataApi').mockResolvedValue([...mockData]);
-
-  jest.spyOn(useTableData, 'default').mockImplementation(dataList => ({
-    columns,
-    data: dataList,
-  }));
-
-  jest.mock('@tanstack/react-query', () => ({
-    ...jest.requireActual('@tanstack/react-query'),
-    useQueryClient: () => ({
-      ...jest.requireActual('@tanstack/react-query').useQueryClient(),
-      useQuery: jest.fn().mockReturnValue({
-        data: {},
-        isLoading: false,
-        isSuccess: true,
-        error: {},
-      }),
-    }),
-  }));
 };
 
 export const renderAll = (children: ReactNode) => {

--- a/src/component/AdminHeader.tsx
+++ b/src/component/AdminHeader.tsx
@@ -8,7 +8,11 @@ const AdminHeader = () => {
     <AdminHeaderWrapper>
       <Title>Today's Orders</Title>
       <HeaderRight>
-        <InputBar value={keyword} onChange={handleChange} />
+        <InputBar
+          data-testid='admin-search-bar'
+          value={keyword}
+          onChange={handleChange}
+        />
         <AiOutlineSearch className='icon' />
       </HeaderRight>
     </AdminHeaderWrapper>

--- a/src/component/common/Table.tsx
+++ b/src/component/common/Table.tsx
@@ -39,9 +39,11 @@ const Table = <T extends object>({ data, columns }: TableProps<T>) => {
       </thead>
       <tbody>
         {table.getRowModel().rows.map(row => (
-          <TableRow key={row.id}>
+          <TableRow data-testid='table-body-row' key={row.id}>
             {row.getVisibleCells().map(cell => (
-              <Td key={cell.id}>
+              <Td
+                data-testid={`table-body-cell-${cell.column.id}`}
+                key={cell.id}>
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </Td>
             ))}

--- a/src/component/common/TableHeader.tsx
+++ b/src/component/common/TableHeader.tsx
@@ -23,6 +23,7 @@ export default function TableHeader<T extends object>({
 
   return (
     <Th
+      data-testid={`table-header-cell-${header.id}`}
       key={header.id}
       onClick={
         allowSortKey(header.id)
@@ -41,6 +42,7 @@ export default function TableHeader<T extends object>({
         ) : null}
         {header.column.getCanFilter() ? (
           <FilterBtn
+            data-testid='table-body-filter-btn'
             onClick={onChange}
             tagValue={header.column.getFilterValue() as undefined | boolean}
           />

--- a/src/hooks/useTableData.ts
+++ b/src/hooks/useTableData.ts
@@ -4,13 +4,13 @@ import { DataType } from './../types/data.types';
 import { ColumnDef } from '@tanstack/react-table';
 import { useMemo } from 'react';
 
+type DataHeaderType = {
+  [index: string]: string;
+};
+
 const useTableData = (dataList: DataType[]) => {
   const columns = useMemo<ColumnDef<DataType>[]>(() => {
     if (!dataList) return [];
-
-    type DataHeaderType = {
-      [index: string]: string;
-    };
 
     const dataHeader: DataHeaderType = {
       id: '주문번호',
@@ -32,6 +32,7 @@ const useTableData = (dataList: DataType[]) => {
       enableSorting: allowSortKey(key) ? true : false,
       enableColumnFilter: key === 'status' ? true : false,
       filterFn: 'equals',
+      sortDescFirst: true,
     }));
   }, [dataList]);
 


### PR DESCRIPTION
## 요구사항
* 컴포넌트에 대한 테스트 코드를 구현해주세요

## 참고 사항
`AdminBody.test.tsx`
- 한 페이지에 오늘의 거래 건으로 50건의 주문이 보여야한다.
- 주문번호, 거래일자 버튼을 누르면 내림차순 정렬이 되어야한다.
- 주문상태를 한번 누르면 true인 데이터들만 보여져야한다.
- 주문상태를 두번 누르면 false인 데이터들만 보여져야한다.

`Mainpage.test.tsx`
- 검색창에 검색하는 단어를 포함한 이름의 고객이 표에 보여져야한다.

